### PR TITLE
Move to stable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rblas = "0.0.10"
 enum_primitive = "0.1.0"
 byteorder = "0.4"
 num = "0.1"
+lazy_static = "0.1.15"
 
 clippy = { version = "0.0.27", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ license       = "MIT"
 [dependencies]
 libc = "0.2"
 bitflags = "0.3"
-rblas = "0.0.10"
+rblas = "0.0.11"
 enum_primitive = "0.1.0"
 byteorder = "0.4"
 num = "0.1"

--- a/src/framework.rs
+++ b/src/framework.rs
@@ -38,7 +38,8 @@ pub trait IFramework {
     ///
     /// For convention, let the ID be uppercase.<br/>
     /// EXAMPLE: OPENCL
-    const ID: &'static str;
+    #[allow(non_snake_case)]
+    fn ID() -> &'static str;
 
     /// Initializes a new Framework.
     ///

--- a/src/frameworks/cuda/mod.rs
+++ b/src/frameworks/cuda/mod.rs
@@ -36,7 +36,8 @@ impl IFramework for Cuda {
     type H = Device;
     type D = Context;
     type B = Module;
-    const ID: &'static str = "CUDA";
+
+    fn ID() -> &'static str { "CUDA" }
 
     fn new() -> Cuda {
         match Cuda::load_hardwares() {

--- a/src/frameworks/native/mod.rs
+++ b/src/frameworks/native/mod.rs
@@ -40,7 +40,7 @@ impl IFramework for Native {
     type D = Cpu;
     type B = Binary;
 
-    const ID: &'static str = "NATIVE";
+    fn ID() -> &'static str { "NATIVE" }
 
     fn new() -> Native {
         match Native::load_hardwares() {

--- a/src/frameworks/opencl/api/platform.rs
+++ b/src/frameworks/opencl/api/platform.rs
@@ -6,7 +6,7 @@ use super::types as cl;
 use super::ffi::*;
 use std::ptr;
 use std::iter::repeat;
-use std::sync::{StaticMutex, MUTEX_INIT};
+use std::sync::Mutex;
 
 impl API {
     /// Returns a list of available platforms.
@@ -22,7 +22,9 @@ impl API {
         // This mutex is used to work around weak OpenCL implementations.
         // On some implementations concurrent calls to clGetPlatformIDs
         // will cause the implantation to return invalid status.
-        static mut platforms_mutex: StaticMutex = MUTEX_INIT;
+        lazy_static! {
+            static ref platforms_mutex: Mutex<()> = Mutex::new(());
+        }
 
         let guard = unsafe {platforms_mutex.lock()};
         try!(unsafe {API::ffi_get_platform_ids(0, ptr::null_mut(), (&mut num_platforms))});

--- a/src/frameworks/opencl/mod.rs
+++ b/src/frameworks/opencl/mod.rs
@@ -50,7 +50,8 @@ impl IFramework for OpenCL {
     type H = Device;
     type D = Context;
     type B = Program;
-    const ID: &'static str = "OPENCL";
+
+    fn ID() -> &'static str { "OPENCL" }
 
     fn new() -> OpenCL {
         match OpenCL::load_hardwares() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@
 #![cfg_attr(lint, feature(plugin))]
 #![cfg_attr(lint, plugin(clippy))]
 #![allow(dead_code)]
-#![feature(static_mutex)]
 #![deny(missing_docs,
         missing_debug_implementations, missing_copy_implementations,
         trivial_casts, trivial_numeric_casts,
@@ -145,6 +144,8 @@ extern crate libc;
 extern crate bitflags;
 #[macro_use]
 extern crate enum_primitive;
+#[macro_use]
+extern crate lazy_static;
 extern crate num;
 extern crate byteorder;
 extern crate rblas as blas;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@
 #![cfg_attr(lint, feature(plugin))]
 #![cfg_attr(lint, plugin(clippy))]
 #![allow(dead_code)]
-#![feature(unboxed_closures)]
 #![feature(static_mutex)]
 #![deny(missing_docs,
         missing_debug_implementations, missing_copy_implementations,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@
 #![cfg_attr(lint, feature(plugin))]
 #![cfg_attr(lint, plugin(clippy))]
 #![allow(dead_code)]
-#![feature(associated_type_defaults)]
 #![feature(unboxed_closures)]
 #![feature(static_mutex)]
 #![deny(missing_docs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,6 @@
 #![cfg_attr(lint, feature(plugin))]
 #![cfg_attr(lint, plugin(clippy))]
 #![allow(dead_code)]
-#![feature(associated_consts)]
 #![feature(associated_type_defaults)]
 #![feature(unboxed_closures)]
 #![feature(static_mutex)]


### PR DESCRIPTION
This PR removes unnecessary use of feature flags that bar using Rust on stable([1])([2]) compilers.

Reasons being:
* associated consts (Tracking issue: https://github.com/rust-lang/rust/issues/29646) are currently buggy and can be replaced by an fn in that case.
* associated_type_defaults can be removed without breakage
* unboxed_closures can be removed without breakage
* StaticMutex has an uncertain future (https://github.com/rust-lang/rust/issues/27717) and can be emulated in that case by using `lazy_static!` (correct me if I'm wrong)

Finally, I must admit that I didn't get the test suite running quickly.

([1]) Outstanding: this doesn't _quite_ work on stable yet, as some APIs in use are currently making their way through beta, so they are not feature gated, but also not available in 1.4.0. 1.5.0 beta works and as 1.5.0 is 2 weeks away, this is probably not worth the effort.
([2]) rblas is not on stable yet, see https://github.com/mikkyang/rust-blas/pull/12 for that. You can use that version of rust-blas by checking it out from my https://github.com/skade/rust-blas/ and dropping the following `.cargo/config` in your repository:

```
paths = ["/path/to/rblas/checkout"]
```