### PR TITLE
chore/clippy: bump clippy version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ enum_primitive = "0.1.0"
 byteorder = "0.4"
 num = "0.1"
 
-clippy = { version = "0.0.23", optional = true }
+clippy = { version = "0.0.27", optional = true }
 
 [features]
 default = []


### PR DESCRIPTION
Update clippy to compile again on current nightly Rust.