### PR TITLE
fix/windows-build: Building collenchyma on Windows

### DIFF
--- a/src/frameworks/cuda/api/memory.rs
+++ b/src/frameworks/cuda/api/memory.rs
@@ -22,12 +22,12 @@ impl API {
 
     /// Copies memory from the Host to the Cuda device.
     pub fn mem_cpy_h_to_d(host_mem: &FlatBox, device_mem: &mut Memory) -> Result<(), Error> {
-        unsafe {API::ffi_mem_cpy_h_to_d(device_mem.id_c(), host_mem.as_slice().as_ptr(), host_mem.byte_size() as u64)}
+        unsafe {API::ffi_mem_cpy_h_to_d(device_mem.id_c(), host_mem.as_slice().as_ptr(), host_mem.byte_size() as size_t)}
     }
 
     /// Copies memory from the Cuda device to the Host.
     pub fn mem_cpy_d_to_h(device_mem: &Memory, host_mem: &mut FlatBox) -> Result<(), Error> {
-        unsafe {API::ffi_mem_cpy_d_to_h(host_mem.as_mut_slice().as_mut_ptr(), device_mem.id_c(), host_mem.byte_size() as u64)}
+        unsafe {API::ffi_mem_cpy_d_to_h(host_mem.as_mut_slice().as_mut_ptr(), device_mem.id_c(), host_mem.byte_size() as size_t)}
     }
 
     unsafe fn ffi_mem_alloc(bytesize: size_t) -> Result<CUdeviceptr, Error> {

--- a/src/frameworks/cuda/context.rs
+++ b/src/frameworks/cuda/context.rs
@@ -72,7 +72,7 @@ impl IDevice for Context {
     }
 
     fn alloc_memory(&self, size: u64) -> Result<Memory, DeviceError> {
-        Ok(try!(API::mem_alloc(size)))
+        Ok(try!(API::mem_alloc(size as size_t)))
     }
 
     fn sync_in(&self, source: &DeviceType, source_data: &MemoryType, dest_data: &mut Memory) -> Result<(), DeviceError> {

--- a/src/frameworks/cuda/memory.rs
+++ b/src/frameworks/cuda/memory.rs
@@ -25,7 +25,7 @@ impl Drop for Memory {
 impl Memory {
     /// Initializes a new Cuda memory.
     pub fn new(size: usize) -> Result<Memory, Error> {
-        API::mem_alloc(size as u64)
+        API::mem_alloc(size as size_t)
     }
 
     /// Initializes a new Cuda memory from its C type.

--- a/src/frameworks/opencl/api/ffi.rs
+++ b/src/frameworks/opencl/api/ffi.rs
@@ -5,6 +5,7 @@
 use libc;
 use super::types as cl;
 
+#[link(name = "OpenCL")]
 extern
 {
     /* Platform APIs */


### PR DESCRIPTION
I got the build and tests running on Windows. 
Along with the changes introduced by the PR, I just had to copy `blas.lib` (from openblas) and `OpenCL.lib` (from CUDA's folder) to the rust toolchain's `lib` folder.

