### PR TITLE
Use size types that depend on the target architecture.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -29,7 +29,7 @@ pub trait IDevice {
     /// Returns the hardwares, which define the Device.
     fn hardwares(&self) -> &Vec<Self::H>;
     /// Allocate memory on the Device.
-    fn alloc_memory(&self, size: u64) -> Result<Self::M, Error>;
+    fn alloc_memory(&self, size: usize) -> Result<Self::M, Error>;
     /// Synchronize memory from `source_data` to the memory at `dest_data`.
     ///
     /// Defines how data is synchronized into the device.

--- a/src/frameworks/cuda/api/driver/ffi.rs
+++ b/src/frameworks/cuda/api/driver/ffi.rs
@@ -3,7 +3,7 @@
 #![allow(non_camel_case_types, non_snake_case)]
 // Created by bindgen
 
-pub type size_t = ::libc::c_ulong;
+pub type size_t = ::libc::size_t;
 pub type wchar_t = ::libc::c_int;
 pub type __u_char = ::libc::c_uchar;
 pub type __u_short = ::libc::c_ushort;

--- a/src/frameworks/cuda/api/driver/memory.rs
+++ b/src/frameworks/cuda/api/driver/memory.rs
@@ -22,12 +22,12 @@ impl API {
 
     /// Copies memory from the Host to the Cuda device.
     pub fn mem_cpy_h_to_d(host_mem: &FlatBox, device_mem: &mut Memory) -> Result<(), Error> {
-        unsafe {API::ffi_mem_cpy_h_to_d(device_mem.id_c(), host_mem.as_slice().as_ptr(), host_mem.byte_size() as size_t)}
+        unsafe {API::ffi_mem_cpy_h_to_d(device_mem.id_c(), host_mem.as_slice().as_ptr(), host_mem.byte_size())}
     }
 
     /// Copies memory from the Cuda device to the Host.
     pub fn mem_cpy_d_to_h(device_mem: &Memory, host_mem: &mut FlatBox) -> Result<(), Error> {
-        unsafe {API::ffi_mem_cpy_d_to_h(host_mem.as_mut_slice().as_mut_ptr(), device_mem.id_c(), host_mem.byte_size() as size_t)}
+        unsafe {API::ffi_mem_cpy_d_to_h(host_mem.as_mut_slice().as_mut_ptr(), device_mem.id_c(), host_mem.byte_size())}
     }
 
     unsafe fn ffi_mem_alloc(bytesize: size_t) -> Result<CUdeviceptr, Error> {

--- a/src/frameworks/cuda/memory.rs
+++ b/src/frameworks/cuda/memory.rs
@@ -29,7 +29,7 @@ impl Drop for Memory {
 impl Memory {
     /// Initializes a new Cuda memory.
     pub fn new(size: usize) -> Result<Memory, DriverError> {
-        Driver::mem_alloc(size as DriverFFI::size_t)
+        Driver::mem_alloc(size)
     }
 
     /// Initializes a new Cuda memory from its C type.

--- a/src/frameworks/native/device.rs
+++ b/src/frameworks/native/device.rs
@@ -37,8 +37,8 @@ impl IDevice for Cpu {
         &self.hardwares
     }
 
-    fn alloc_memory(&self, size: u64) -> Result<FlatBox, DeviceError> {
-        let vec: Vec<u8> = vec![0; size as usize];
+    fn alloc_memory(&self, size: usize) -> Result<FlatBox, DeviceError> {
+        let vec: Vec<u8> = vec![0; size];
         let bx: Box<[u8]> = vec.into_boxed_slice();
         Ok(FlatBox::from_box(bx))
     }

--- a/src/frameworks/opencl/context.rs
+++ b/src/frameworks/opencl/context.rs
@@ -81,8 +81,8 @@ impl IDevice for Context {
         &self.devices
     }
 
-    fn alloc_memory(&self, size: u64) -> Result<Memory, DeviceError> {
-        Ok(try!(Memory::new(self, size as usize)))
+    fn alloc_memory(&self, size: usize) -> Result<Memory, DeviceError> {
+        Ok(try!(Memory::new(self, size)))
     }
 
     fn sync_in(&self, source: &DeviceType, source_data: &MemoryType, dest_data: &mut Memory) -> Result<(), DeviceError> {

--- a/src/shared_memory.rs
+++ b/src/shared_memory.rs
@@ -233,10 +233,10 @@ impl<T, D: ITensor> SharedMemory<T, D> {
         let copy: MemoryType;
         let alloc_size = Self::mem_size(dim.elements());
         match *dev {
-            DeviceType::Native(ref cpu) => copy = MemoryType::Native(try!(cpu.alloc_memory(alloc_size as u64))),
-            DeviceType::OpenCL(ref context) => copy = MemoryType::OpenCL(try!(context.alloc_memory(alloc_size as u64))),
+            DeviceType::Native(ref cpu) => copy = MemoryType::Native(try!(cpu.alloc_memory(alloc_size))),
+            DeviceType::OpenCL(ref context) => copy = MemoryType::OpenCL(try!(context.alloc_memory(alloc_size))),
             #[cfg(feature = "cuda")]
-            DeviceType::Cuda(ref context) => copy = MemoryType::Cuda(try!(context.alloc_memory(alloc_size as u64))),
+            DeviceType::Cuda(ref context) => copy = MemoryType::Cuda(try!(context.alloc_memory(alloc_size))),
         }
         Ok(SharedMemory {
             latest_location: dev.clone(),
@@ -349,10 +349,10 @@ impl<T, D: ITensor> SharedMemory<T, D> {
             None => {
                 let copy: MemoryType;
                 match *device {
-                    DeviceType::Native(ref cpu) => copy = MemoryType::Native(try!(cpu.alloc_memory(Self::mem_size(self.capacity()) as u64))),
-                    DeviceType::OpenCL(ref context) => copy = MemoryType::OpenCL(try!(context.alloc_memory(Self::mem_size(self.capacity()) as u64))),
+                    DeviceType::Native(ref cpu) => copy = MemoryType::Native(try!(cpu.alloc_memory(Self::mem_size(self.capacity())))),
+                    DeviceType::OpenCL(ref context) => copy = MemoryType::OpenCL(try!(context.alloc_memory(Self::mem_size(self.capacity())))),
                     #[cfg(feature = "cuda")]
-                    DeviceType::Cuda(ref context) => copy = MemoryType::Cuda(try!(context.alloc_memory(Self::mem_size(self.capacity()) as u64))),
+                    DeviceType::Cuda(ref context) => copy = MemoryType::Cuda(try!(context.alloc_memory(Self::mem_size(self.capacity())))),
                 };
                 self.copies.insert(device.clone(), copy);
                 Ok(self)


### PR DESCRIPTION
The build broke on my side, due to a mismatched type between `u32` and `u64` in the cuda bindings

This replaces u32 and u64 with usize (or libc::size_t) where the expected type is a pointer size.
It should make the build more robust over different target architectures.