### PR TITLE
for macos

### DIFF
--- a/src/frameworks/opencl/api/ffi.rs
+++ b/src/frameworks/opencl/api/ffi.rs
@@ -5,7 +5,8 @@
 use libc;
 use super::types as cl;
 
-#[link(name = "OpenCL")]
+#[cfg_attr(target_os = "macos", link(name = "OpenCL", kind = "framework"))]
+#[cfg_attr(not(target_os = "macos"), link(name = "OpenCL"))]
 extern
 {
     /* Platform APIs */


### PR DESCRIPTION
For OS X, you need the kind key of "framework".

This patch and adding build.rs as below made compilation successful on Mac.

    fn main() {
        let YOUR_CUDA_LIB_PATH = "";
        println!("cargo:rustc-link-search=native={}", YOUR_CUDA_LIB_PATH);
    }
