### PR TITLE
feat/tensor: implement IntoTensorDesc for [usize; N], N=1...6

### DIFF
--- a/src/tensor.rs
+++ b/src/tensor.rs
@@ -201,6 +201,20 @@ impl IntoTensorDesc for (usize, usize, usize, usize, usize, usize) {
     }
 }
 
+macro_rules! impl_array_into_tensor_desc {
+    ($($N:expr)+) => {
+        $(
+            impl IntoTensorDesc for [usize; $N] {
+                fn into(&self) -> TensorDesc {
+                    let slice: &[_] = self;
+                    From::from(slice)
+                }
+            }
+        )+
+    }
+}
+impl_array_into_tensor_desc!(1 2 3 4 5 6);
+
 impl ITensorDesc for TensorDesc {
     fn rank(&self) -> usize {
         self.len()


### PR DESCRIPTION
Currently dimensions of a tensor can be specified with usize, tuples, Vecs
and slices:

    SharedTensor::new(backend, &10)
    SharedTensor::new(backend, &(10, 2))
    SharedTensor::new(backend, &vec![10, 2])

In cases like this, vec! causes an unneeded allocation and is a bit more
verbose than possible. Usize/tuple syntax looks somewhat irregular. It would
be nice to be able to express tensor creation like this:

    SharedTensor::new(backend, &[10, 2])

But Rust doesn't autocoerce `&[usize; _]` into `&[usize]`. This patch adds explicit
implementations to make this use case work.

Package version is also bumped to make it possible to depend on this feature.