### PR TITLE
chore/osx: support building on os x and test this on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,84 @@
 language: rust
-rust:
-- nightly
-- beta
-- stable
+
 matrix:
   allow_failures:
-    - rust: nightly
-      env: FEATURES=lint
-  exclude:
-    - rust: beta
-      env: FEATURES=lint
-    - rust: stable
-      env: FEATURES=lint
+    - env: FEATURES=travis lint
+  include:
+    - os: linux
+      rust: stable
+      env: FEATURES=travis
+      addons: &linuxaddons
+        apt:
+          packages:
+          - libcurl4-openssl-dev
+          - libelf-dev
+          - libdw-dev
+          - libblas-dev
+
+    - os: linux
+      rust: beta
+      env: FEATURES=travis
+      addons: *linuxaddons
+
+    - os: linux
+      rust: nightly
+      env: FEATURES=travis
+      addons: *linuxaddons
+
+    - os: linux
+      rust: nightly
+      env: FEATURES=travis lint
+      addons: *linuxaddons
+
+    - os: osx
+      osx_image: osx10.11
+      rust: stable
+      env: FEATURES=travis
+      install: &osxinstall
+        - brew update || true
+        - brew install openssl
+        - brew install libelf
+        - brew install dwarf
+        - brew install homebrew/science/openblas
+        - brew install python # For pip
+
+    - os: osx
+      osx_image: osx10.11
+      rust: beta
+      env: FEATURES=travis
+      install: *osxinstall
+
+    - os: osx
+      osx_image: osx10.11
+      rust: nightly
+      env: FEATURES=travis
+      install: *osxinstall
+
+    - os: osx
+      osx_image: osx10.11
+      rust: nightly
+      env: FEATURES=travis lint
+      install: *osxinstall
+
+
 before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:$PATH
+  - pip install 'travis-cargo<0.2' --user
+  - export PATH=`python -c 'import site; print site.USER_BASE'`/bin:$PATH
+
 script:
-- |
-  travis-cargo build -- --no-default-features --features $FEATURES &&
-  travis-cargo test -- --no-default-features --features $FEATURES &&
-  travis-cargo bench -- --no-default-features --features $FEATURES &&
-  travis-cargo doc -- --no-default-features --features $FEATURES
-addons:
-  apt:
-    packages:
-    - libcurl4-openssl-dev
-    - libelf-dev
-    - libdw-dev
-    - libblas-dev
+  - travis-cargo build -- --no-default-features --features $FEATURES
+  - travis-cargo test -- --no-default-features --features $FEATURES
+  - travis-cargo bench -- --no-default-features --features $FEATURES
+  - travis-cargo doc -- --no-default-features --features $FEATURES
+
 after_success:
-- travis-cargo doc-upload
-- travis-cargo coveralls --no-sudo
+  - travis-cargo doc-upload
+  - travis-cargo coveralls --no-sudo
+
 notifications:
   email:
     on_success: never
+
 env:
   global:
     - secure: iq9uF0iCndl7hnnUmtL9qdYaDvBvPGrImFtrDq1XtJQoNurXYO9OXyOyTIBGFIRkwfEt8Fk79cWaif6hktpammv/0uWrVzRQd8b6stOFRjOJ9fJ46ETQcNn3usr2YrRdTm7k01GXB1U5RSyYYiG63pcIkcui2NgOmnqZaCuQ4pJsHWQVGUbBey5vLTEC1zAdfYY4V9554yVW1V+eA9Atdnur8f9gUbkkG/XKhoKcpT3UtS6MD7MAPIH1Rnrf8GXIc1NAxzLD0zcKBo2o3yIbfGMm4RgRnmI6tRZBI0MgDoB8/1AGLZbBWoSaB5d7S8f/ghqzMu2AnM1HO26sTGYvy0kwt9DAmdBVcB82yFV4y4KMCr0R0Kz9XO3jukl42cmyPyYWAFQG8TO+/LjvPuj1PDSTvvvvit9QotCS+q9FE2aG5lag6W55GlMNPhR2JqLQtuCSaEgkDOmGQIDvZLkceekC2gC6/ryVcDNOUEYyUFrLpd20koDfuttth73tnYgcDIqWIoZ5nhQw1ciXfkSiP9/rOFKTZZXvO0KVgVi95Pwn4xjbBPOWQelIJtOzGRzehUaBnYZWKVFsyk7d7BVK9hWWv2DeOsbGc5Oz9X70ThAA/9d3E2vjVlJmwrijVSWnga/SJFhV5XgYaAO1vHe2tMDJGtGAT9B4ZWjuudNYPyg=
-  matrix:
-    - FEATURES=travis
-    - FEATURES=lint

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ linear-map = "0.0.4"
 clippy = { version = "0.0.27", optional = true }
 
 [dev-dependencies]
-
 rand = "0.3"
 
 [features]


### PR DESCRIPTION
The newly-added build script adds the default installation location of cuda to
rustc's library search path.

Fixes #46